### PR TITLE
Rename gaussiansplatting to splatfacto

### DIFF
--- a/garfield/garfield_config.py
+++ b/garfield/garfield_config.py
@@ -11,7 +11,7 @@ from nerfstudio.engine.trainer import TrainerConfig
 from nerfstudio.data.datamanagers.full_images_datamanager import (
     FullImageDatamanagerConfig,
 )
-from nerfstudio.models.gaussian_splatting import GaussianSplattingModelConfig
+from nerfstudio.models.splatfacto import SplatfactoModelConfig
 from nerfstudio.data.dataparsers.colmap_dataparser import ColmapDataParserConfig
 
 from garfield.garfield_pipeline import GarfieldPipelineConfig
@@ -101,7 +101,7 @@ garfield_gauss_method = MethodSpecification(
             datamanager=FullImageDatamanagerConfig(
                 dataparser=ColmapDataParserConfig(load_3D_points=True),
             ),
-            model=GaussianSplattingModelConfig(
+            model=SplatfactoModelConfig(
                 cull_alpha_thresh=0.2,
                 use_scale_regularization=True,
             ),

--- a/garfield/garfield_gaussian_pipeline.py
+++ b/garfield/garfield_gaussian_pipeline.py
@@ -15,10 +15,10 @@ from nerfstudio.pipelines.base_pipeline import VanillaPipeline, VanillaPipelineC
 from torch.cuda.amp.grad_scaler import GradScaler
 from nerfstudio.viewer.viewer_elements import *
 from nerfstudio.viewer.viewer import VISER_NERFSTUDIO_SCALE_RATIO
-from nerfstudio.models.gaussian_splatting import GaussianSplattingModel
+from nerfstudio.models.splatfacto import SplatfactoModel
 
 from cuml.cluster.hdbscan import HDBSCAN
-from nerfstudio.models.gaussian_splatting import RGB2SH
+from nerfstudio.models.splatfacto import RGB2SH
 
 import tqdm
 
@@ -60,7 +60,7 @@ class GarfieldGaussianPipeline(VanillaPipeline):
 
     Note that the pipeline training must be stopped before you can interact with the scene!!
     """
-    model: GaussianSplattingModel
+    model: SplatfactoModel
     garfield_pipeline: List[GarfieldPipeline]  # To avoid importing Viewer* from nerf pipeline
     state_stack: List[Dict[str, TensorType]]  # To revert to previous state
     click_location: Optional[TensorType]  # For storing click location


### PR DESCRIPTION
Main branch of nerfstudio renamed `GaussianSplattingModel` to `SplatfactoModel`. Migration.