### PR TITLE
Support superpixels for 2D groups

### DIFF
--- a/garfield/garfield_config.py
+++ b/garfield/garfield_config.py
@@ -42,7 +42,7 @@ garfield_method = MethodSpecification(
                 ),
                 img_group_model=ImgGroupModelConfig(
                     model_type="sam_hf",  
-                    # Can choose out of "sam_fb", "sam_hf", "maskformer"
+                    # Can choose out of "sam_fb", "sam_hf", "maskformer", "superpixel"
                     # Used sam_fb for the paper, see `img_group_model.py`. 
                     device="cuda",
                 ),

--- a/garfield/img_group_model.py
+++ b/garfield/img_group_model.py
@@ -18,7 +18,7 @@ from nerfstudio.configs import base_config as cfg
 class ImgGroupModelConfig(cfg.InstantiateConfig):
     _target: Type = field(default_factory=lambda: ImgGroupModel)
     """target class to instantiate"""
-    model_type: Literal["sam_fb", "sam_hf", "maskformer"] = "sam_fb"
+    model_type: Literal["sam_fb", "sam_hf", "maskformer", "superpixel"] = "sam_fb"
     """
     Currently supports:
      - "sam_fb": Original SAM model (from facebook github)
@@ -92,6 +92,20 @@ class ImgGroupModel:
             masks = [
                 (np.array(m['mask']) != 0)
                 for m in masks
+            ]
+            masks = sorted(masks, key=lambda x: x.sum())
+            return masks
+
+        elif self.config.model_type == "superpixel":
+            from skimage.segmentation import felzenszwalb, slic, quickshift, watershed
+            img = Image.fromarray(img)
+            # masks = slic(np.array(img), n_segments=100, compactness=10, channel_axis=2)
+            masks = felzenszwalb(img, scale=200, sigma=0.5, min_size=50)
+            if masks.max() <= 1:
+                masks = slic(np.array(img), n_segments=100, compactness=10, channel_axis=2)
+            masks = [
+                (masks == i)
+                for i in range(masks.max() + 1)
             ]
             masks = sorted(masks, key=lambda x: x.sum())
             return masks


### PR DESCRIPTION
Superpixels in 2D can provide reasonable supervision for 3D groups, like below:

<img width="1242" alt="image" src="https://github.com/chungmin99/garfield/assets/10284938/bec12cdc-6f2b-4c42-8c26-7bdf9acdad28">

Smaller scale can pick apart the logo / smaller objects:

<img width="1242" alt="image" src="https://github.com/chungmin99/garfield/assets/10284938/033e30b2-b4a7-4945-8cbb-f1442a0070bc">

<img width="1242" alt="image" src="https://github.com/chungmin99/garfield/assets/10284938/6f17c957-3aab-450e-964b-f6bb72a12611">


At a larger scale it can include bigger groups:

<img width="1242" alt="image" src="https://github.com/chungmin99/garfield/assets/10284938/52b55e84-0bdf-4115-bc3f-ed1841dc6b1d">

<img width="1242" alt="image" src="https://github.com/chungmin99/garfield/assets/10284938/80bfc1fe-d245-4a63-987c-11e9e37f2280">


It's definitely not as good as the SAM multi level mask groups, but it's worth exploring this type of texture-based grouping as well. 