### PR TITLE
Fix bug preventing nerfstudio from running: switching to default_factory.

### DIFF
--- a/garfield/garfield_datamanager.py
+++ b/garfield/garfield_datamanager.py
@@ -35,7 +35,7 @@ from garfield.garfield_pixel_sampler import GarfieldPixelSampler
 class GarfieldDataManagerConfig(VanillaDataManagerConfig):
     _target: Type = field(default_factory=lambda: GarfieldDataManager)
     """The datamanager class to use."""
-    img_group_model: ImgGroupModelConfig = field(default_factory=lambda: ImgGroupModelConfig)
+    img_group_model: ImgGroupModelConfig = field(default_factory=lambda: ImgGroupModelConfig())
     """The SAM model to use. This can be any other model that outputs masks..."""
 
 

--- a/garfield/garfield_datamanager.py
+++ b/garfield/garfield_datamanager.py
@@ -35,7 +35,7 @@ from garfield.garfield_pixel_sampler import GarfieldPixelSampler
 class GarfieldDataManagerConfig(VanillaDataManagerConfig):
     _target: Type = field(default_factory=lambda: GarfieldDataManager)
     """The datamanager class to use."""
-    img_group_model: ImgGroupModelConfig = ImgGroupModelConfig()
+    img_group_model: ImgGroupModelConfig = field(default_factory=lambda: ImgGroupModelConfig)
     """The SAM model to use. This can be any other model that outputs masks..."""
 
 

--- a/garfield/garfield_gaussian_pipeline.py
+++ b/garfield/garfield_gaussian_pipeline.py
@@ -25,7 +25,7 @@ import tqdm
 from sklearn.preprocessing import QuantileTransformer
 from sklearn.neighbors import NearestNeighbors
 
-from gsplat._torch_impl import quat_to_rotmat
+from gsplat.cuda_legacy._torch_impl import quat_to_rotmat
 from scipy.spatial.transform import Rotation as Rot
 
 from garfield.garfield_datamanager import GarfieldDataManagerConfig, GarfieldDataManager

--- a/garfield/garfield_model.py
+++ b/garfield/garfield_model.py
@@ -41,7 +41,7 @@ class FeatureRenderer(nn.Module):
 @dataclass
 class GarfieldModelConfig(NerfactoModelConfig):
     _target: Type = field(default_factory=lambda: GarfieldModel)
-    instance_field: GarfieldFieldConfig = GarfieldFieldConfig()
+    instance_field: GarfieldFieldConfig = field(default_factory=lambda: GarfieldFieldConfig())
 
     max_grouping_scale: float = 2.0
     """Maximum scale to use for grouping supervision. Should be set during pipeline init."""

--- a/garfield/garfield_pipeline.py
+++ b/garfield/garfield_pipeline.py
@@ -20,8 +20,8 @@ class GarfieldPipelineConfig(VanillaPipelineConfig):
     _target: Type = field(default_factory=lambda: GarfieldPipeline)
     """target class to instantiate"""
 
-    datamanager: GarfieldDataManagerConfig = GarfieldDataManagerConfig()
-    model: GarfieldModelConfig = GarfieldModelConfig()
+    datamanager: GarfieldDataManagerConfig = field(default_factory=lambda: GarfieldDataManagerConfig())
+    model: GarfieldModelConfig = field(default_factory=lambda: GarfieldModelConfig())
 
     start_grouping_step: int = 2000
     max_grouping_scale: float = 2.0


### PR DESCRIPTION
When installing garfield, running nerfstudio with any algorithm (not just garfield) results in an error similar to the following: 
```
Traceback (most recent call last):
  File "/home/theo/miniconda3/envs/nerfstudio2/bin/ns-train", line 5, in <module>
    from nerfstudio.scripts.train import entrypoint
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/site-packages/nerfstudio/scripts/train.py", line 62, in <module>
    from nerfstudio.configs.method_configs import AnnotatedBaseConfigUnion
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/site-packages/nerfstudio/configs/method_configs.py", line 729, in <module>
    all_methods, all_descriptions = merge_methods(all_methods, all_descriptions, *discover_methods())
                                                                                  ^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/site-packages/nerfstudio/plugins/registry.py", line 43, in discover_methods
    spec = discovered_entry_points[name].load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/site-packages/importlib_metadata/__init__.py", line 184, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/tmp/garfield/garfield/garfield_config.py", line 17, in <module>
    from garfield.garfield_pipeline import GarfieldPipelineConfig
  File "/home/theo/tmp/garfield/garfield/garfield_pipeline.py", line 12, in <module>
    from garfield.garfield_datamanager import GarfieldDataManagerConfig, GarfieldDataManager
  File "/home/theo/tmp/garfield/garfield/garfield_datamanager.py", line 34, in <module>
    @dataclass
     ^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/theo/miniconda3/envs/nerfstudio2/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'garfield.img_group_model.ImgGroupModelConfig'> for field img_group_model is not allowed: use default_factory 
```
This PR changes all the problematic instances to use `default_factory` instead resolving the issue. 

In case this has to do with new software versions/specific software versions: 
Environment: Python 3.11.8, torch 2.3.0, cuda 12.1, nerfstudio & garfield latest main branch
